### PR TITLE
Ignore logical type conversion and just deliver already converted value if its type matches the target type

### DIFF
--- a/_examples/kotlin-example/src/test/kotlin/BankAccountCreatedDataTest.kt
+++ b/_examples/kotlin-example/src/test/kotlin/BankAccountCreatedDataTest.kt
@@ -4,6 +4,7 @@ import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
 import io.toolisticon.kotlin.avro.example.customerid.CustomerId
 import io.toolisticon.kotlin.avro.example.money.MoneyLogicalType
 import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.AvroKotlinSerialization
 import io.toolisticon.kotlin.avro.value.CanonicalName.Companion.toCanonicalName
 import io.toolisticon.kotlin.avro.value.Name.Companion.toName
 import org.assertj.core.api.Assertions.assertThat
@@ -25,7 +26,24 @@ internal class BankAccountCreatedDataTest {
   }
 
   @Test
-  fun `serialize single object with uuid customerId and money`() {
+  fun `serialize data class with uuid customerId and money to generic record and back`() {
+    val amount = Money.of(10, "EUR")
+    val accountId = UUID.randomUUID()
+    val customerId = CustomerId.random()
+
+    val event = BankAccountCreatedData(accountId, customerId, amount)
+    // val resolver = avroSchemaResolver(KotlinExample.avro.schema(BankAccountCreatedData::class))
+
+    val record = KotlinExample.avro.toRecord(event)
+
+    // val json = GenericRecordCodec.encodeJson(record)
+    // val decodedRecord = GenericRecordCodec.decodeJson(json, KotlinExample.avro.schema(BankAccountCreatedData::class))
+
+    assertThat(KotlinExample.avro.fromRecord(record, BankAccountCreatedData::class)).isEqualTo(event)
+  }
+
+  @Test
+  fun `serialize data class with uuid customerId and money to record and single object encoded and back`() {
     val amount = Money.of(10, "EUR")
     val accountId = UUID.randomUUID()
     val customerId = CustomerId.random()
@@ -35,10 +53,13 @@ internal class BankAccountCreatedDataTest {
 
     val record = KotlinExample.avro.toRecord(event)
 
-    val json = GenericRecordCodec.encodeJson(record)
-
-    val decodedRecord = GenericRecordCodec.decodeJson(json, KotlinExample.avro.schema(BankAccountCreatedData::class))
-
     assertThat(KotlinExample.avro.fromRecord(record, BankAccountCreatedData::class)).isEqualTo(event)
+
+    // go down and run through SOE
+
+    val singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(record)
+    val recordDecodedFromBytes = GenericRecordCodec.decodeSingleObject(singleObjectEncodedBytes, resolver.invoke())
+    val deserializedEvent = AvroKotlinSerialization().fromRecord<BankAccountCreatedData>(recordDecodedFromBytes)
+    assertThat(deserializedEvent).isEqualTo(event)
   }
 }

--- a/_examples/pom.xml
+++ b/_examples/pom.xml
@@ -35,6 +35,23 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>io.github.microutils</groupId>
+        <artifactId>kotlin-logging-jvm</artifactId>
+        <version>3.0.5</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.13</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/_mvn/coverage-aggregator/pom.xml
+++ b/_mvn/coverage-aggregator/pom.xml
@@ -1,0 +1,80 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.toolisticon.kotlin.avro._</groupId>
+    <artifactId>avro-kotlin-root</artifactId>
+    <version>1.11.4.4-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>avro-kotlin-coverage-aggregator</artifactId>
+  <name>coverage: ${project.artifactId}</name>
+  <description>Coverage aggregator for avro-kotlin summarizing coverage reports.</description>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- excluded from install/deploy/release -->
+    <maven.install.skip>true</maven.install.skip>
+    <gpg.skip>true</gpg.skip>
+  </properties>
+
+
+  <dependencies>
+    <!-- AVRO-KOTLIN -->
+    <dependency>
+      <groupId>io.toolisticon.kotlin.avro</groupId>
+      <artifactId>avro-kotlin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- AVRO-KOTLIN-SERIALIZATION -->
+    <dependency>
+      <groupId>io.toolisticon.kotlin.avro</groupId>
+      <artifactId>avro-kotlin-serialization</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- AVRO-KOTLIN-TEST -->
+    <dependency>
+      <groupId>io.toolisticon.kotlin.avro.test</groupId>
+      <artifactId>avro-kotlin-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+
+    <!-- Kotlin example -->
+    <dependency>
+      <groupId>io.toolisticon.kotlin.avro.examples</groupId>
+      <artifactId>kotlin-example</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>coverage-aggregate</id>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <phase>post-integration-test</phase>
+            <configuration>
+              <includeCurrentProject>true</includeCurrentProject>
+              <dataFileIncludes>**/*.exec</dataFileIncludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/BooleanLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/BooleanLogicalTypeSerializer.kt
@@ -14,8 +14,12 @@ abstract class BooleanLogicalTypeSerializer<LOGICAL : BooleanLogicalType, CONVER
   primitiveKind = PrimitiveKind.BOOLEAN
 ) {
   override fun decodeAvroValue(schema: Schema, decoder: ExtendedDecoder): CONVERTED_TYPE {
-    val value = decoder.decodeBoolean()
-    return conversion.fromAvro(value)
+    val value = requireNotNull(decoder.decodeAny()) { "Can't deserialize null" }
+    @Suppress("UNCHECKED_CAST")
+    return when(value::class) {
+      conversion.convertedType -> value as CONVERTED_TYPE
+      else -> conversion.fromAvro(decoder.decodeBoolean())
+    }
   }
 
   override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: CONVERTED_TYPE) {

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/BytesLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/BytesLogicalTypeSerializer.kt
@@ -4,6 +4,7 @@ import com.github.avrokotlin.avro4k.decoder.ExtendedDecoder
 import com.github.avrokotlin.avro4k.encoder.ExtendedEncoder
 import io.toolisticon.kotlin.avro.logical.BytesLogicalType
 import io.toolisticon.kotlin.avro.logical.conversion.BytesLogicalTypeConversion
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import org.apache.avro.Schema
 import java.nio.ByteBuffer
@@ -15,14 +16,17 @@ abstract class BytesLogicalTypeSerializer<LOGICAL : BytesLogicalType, CONVERTED_
   primitiveKind = PrimitiveKind.BYTE
 ) {
   override fun decodeAvroValue(schema: Schema, decoder: ExtendedDecoder): CONVERTED_TYPE {
-    val value = decoder.decodeAny()
-    require(value is ByteArray)
-    return conversion.fromAvro(value)
+    val value = requireNotNull(decoder.decodeAny()) { "Can't deserialize null" }
+    @Suppress("UNCHECKED_CAST")
+    return when(value::class) {
+      conversion.convertedType -> value as CONVERTED_TYPE
+      ByteArray::class -> conversion.fromAvro(value as ByteArray)
+      else -> throw SerializationException("Can't deserialize $value")
+    }
   }
 
   override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: CONVERTED_TYPE) {
     val buffer = ByteBuffer.wrap(conversion.toAvro(obj))
-
     return encoder.encodeByteArray(buffer)
   }
 }

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/DoubleLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/DoubleLogicalTypeSerializer.kt
@@ -14,8 +14,12 @@ abstract class DoubleLogicalTypeSerializer<LOGICAL : DoubleLogicalType, CONVERTE
   primitiveKind = PrimitiveKind.DOUBLE
 ) {
   override fun decodeAvroValue(schema: Schema, decoder: ExtendedDecoder): CONVERTED_TYPE {
-    val value = decoder.decodeDouble()
-    return conversion.fromAvro(value)
+    val value = requireNotNull(decoder.decodeAny()) { "Can't deserialize null" }
+    @Suppress("UNCHECKED_CAST")
+    return when(value::class) {
+      conversion.convertedType -> value as CONVERTED_TYPE
+      else -> conversion.fromAvro(decoder.decodeDouble())
+    }
   }
 
   override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: CONVERTED_TYPE) {

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/FloatLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/FloatLogicalTypeSerializer.kt
@@ -14,8 +14,12 @@ abstract class FloatLogicalTypeSerializer<LOGICAL : FloatLogicalType, CONVERTED_
   primitiveKind = PrimitiveKind.FLOAT
 ) {
   override fun decodeAvroValue(schema: Schema, decoder: ExtendedDecoder): CONVERTED_TYPE {
-    val value = decoder.decodeFloat()
-    return conversion.fromAvro(value)
+    val value = requireNotNull(decoder.decodeAny()) { "Can't deserialize null" }
+    @Suppress("UNCHECKED_CAST")
+    return when(value::class) {
+      conversion.convertedType -> value as CONVERTED_TYPE
+      else -> conversion.fromAvro(decoder.decodeFloat())
+    }
   }
 
   override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: CONVERTED_TYPE) {

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/IntLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/IntLogicalTypeSerializer.kt
@@ -14,8 +14,12 @@ abstract class IntLogicalTypeSerializer<LOGICAL : IntLogicalType, CONVERTED_TYPE
   primitiveKind = PrimitiveKind.INT
 ) {
   override fun decodeAvroValue(schema: Schema, decoder: ExtendedDecoder): CONVERTED_TYPE {
-    val value = decoder.decodeInt()
-    return conversion.fromAvro(value)
+    val value = requireNotNull(decoder.decodeAny()) { "Can't deserialize null" }
+    @Suppress("UNCHECKED_CAST")
+    return when(value::class) {
+      conversion.convertedType -> value as CONVERTED_TYPE
+      else -> conversion.fromAvro(decoder.decodeInt())
+    }
   }
 
   override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: CONVERTED_TYPE) {

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/LongLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/LongLogicalTypeSerializer.kt
@@ -14,8 +14,12 @@ abstract class LongLogicalTypeSerializer<LOGICAL : LongLogicalType, CONVERTED_TY
   primitiveKind = PrimitiveKind.LONG
 ) {
   override fun decodeAvroValue(schema: Schema, decoder: ExtendedDecoder): CONVERTED_TYPE {
-    val value = decoder.decodeLong()
-    return conversion.fromAvro(value)
+    val value = requireNotNull(decoder.decodeAny()) { "Can't deserialize null" }
+    @Suppress("UNCHECKED_CAST")
+    return when(value::class) {
+      conversion.convertedType -> value as CONVERTED_TYPE
+      else -> conversion.fromAvro(decoder.decodeLong())
+    }
   }
 
   override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: CONVERTED_TYPE) {

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/StringLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/StringLogicalTypeSerializer.kt
@@ -4,8 +4,10 @@ import com.github.avrokotlin.avro4k.decoder.ExtendedDecoder
 import com.github.avrokotlin.avro4k.encoder.ExtendedEncoder
 import io.toolisticon.kotlin.avro.logical.StringLogicalType
 import io.toolisticon.kotlin.avro.logical.conversion.StringLogicalTypeConversion
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import org.apache.avro.Schema
+import org.apache.avro.util.Utf8
 
 abstract class StringLogicalTypeSerializer<LOGICAL : StringLogicalType, CONVERTED_TYPE : Any>(
   conversion: StringLogicalTypeConversion<LOGICAL, CONVERTED_TYPE>
@@ -14,8 +16,13 @@ abstract class StringLogicalTypeSerializer<LOGICAL : StringLogicalType, CONVERTE
   primitiveKind = PrimitiveKind.STRING
 ) {
   override fun decodeAvroValue(schema: Schema, decoder: ExtendedDecoder): CONVERTED_TYPE {
-    val stringValue = decoder.decodeString()
-    return conversion.fromAvro(stringValue)
+    val value = requireNotNull(decoder.decodeAny()) { "Can't deserialize null" }
+    @Suppress("UNCHECKED_CAST")
+    return when(value::class) {
+      conversion.convertedType -> value as CONVERTED_TYPE
+      Utf8::class -> conversion.fromAvro(decoder.decodeString())
+      else -> throw SerializationException("Could not decode $value of type ${value::class}")
+    }
   }
 
   override fun encodeAvroValue(schema: Schema, encoder: ExtendedEncoder, obj: CONVERTED_TYPE) {

--- a/avro-kotlin-serialization/src/main/kotlin/serializer/StringLogicalTypeSerializer.kt
+++ b/avro-kotlin-serialization/src/main/kotlin/serializer/StringLogicalTypeSerializer.kt
@@ -20,8 +20,7 @@ abstract class StringLogicalTypeSerializer<LOGICAL : StringLogicalType, CONVERTE
     @Suppress("UNCHECKED_CAST")
     return when(value::class) {
       conversion.convertedType -> value as CONVERTED_TYPE
-      Utf8::class -> conversion.fromAvro(decoder.decodeString())
-      else -> throw SerializationException("Could not decode $value of type ${value::class}")
+      else -> conversion.fromAvro(decoder.decodeString())
     }
   }
 

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/BooleanLogicalTypeSerializerTest.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/BooleanLogicalTypeSerializerTest.kt
@@ -1,0 +1,38 @@
+package io.toolisticon.kotlin.avro.serialization.serializer
+
+import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
+import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBooleanLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestDoubleLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.avroSerialization
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BooleanLogicalTypeSerializerTest {
+
+  data class MyBooleanType(val value: Boolean)
+
+  @Serializable
+  data class Data(
+    @Serializable(with = TestBooleanLogicalType.TypeSerializer::class)
+    val intValue: MyBooleanType
+  )
+
+  private val data = Data(intValue = MyBooleanType(true))
+
+  @Test
+  fun `reads forth and back`() {
+    val record = avroSerialization.toRecord(data)
+    assertThat(avroSerialization.fromRecord(record, Data::class)).isEqualTo(data)
+  }
+
+  @Test
+  fun `reads forth and back from already converted logical type`() {
+    val passedRecord = GenericRecordCodec.decodeSingleObject(
+      singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(avroSerialization.toRecord(data)),
+      readerSchema = avroSchemaResolver(avroSerialization.schema(Data::class)).invoke(),
+    )
+    assertThat(avroSerialization.fromRecord(passedRecord, Data::class)).isEqualTo(data)
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/BytesLogicalTypeSerializerTest.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/BytesLogicalTypeSerializerTest.kt
@@ -1,0 +1,52 @@
+package io.toolisticon.kotlin.avro.serialization.serializer
+
+import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
+import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBytesLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.avroSerialization
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class BytesLogicalTypeSerializerTest {
+
+  data class MyBytesType(val value: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (javaClass != other?.javaClass) return false
+
+      other as MyBytesType
+
+      return value.contentEquals(other.value)
+    }
+
+    override fun hashCode(): Int {
+      return value.contentHashCode()
+    }
+  }
+
+  @Serializable
+  data class Data(
+    @Serializable(with = TestBytesLogicalType.TypeSerializer::class)
+    val byteValue: MyBytesType
+  )
+
+  private val data = Data(byteValue = MyBytesType("AB".toByteArray()))
+
+  @Disabled("find out why this one is failing")
+  @Test
+  fun `reads forth and back`() {
+    val record = avroSerialization.toRecord(data)
+    assertThat(avroSerialization.fromRecord(record, Data::class)).isEqualTo(data)
+  }
+
+  @Test
+  fun `reads forth and back from already converted logical type`() {
+    val passedRecord = GenericRecordCodec.decodeSingleObject(
+      singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(avroSerialization.toRecord(data)),
+      readerSchema = avroSchemaResolver(avroSerialization.schema(Data::class)).invoke(),
+    )
+    assertThat(avroSerialization.fromRecord(passedRecord, Data::class)).isEqualTo(data)
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/DoubleLogicalTypeSerializerTest.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/DoubleLogicalTypeSerializerTest.kt
@@ -1,0 +1,37 @@
+package io.toolisticon.kotlin.avro.serialization.serializer
+
+import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
+import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestDoubleLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.avroSerialization
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DoubleLogicalTypeSerializerTest {
+
+  data class MyDoubleType(val value: Double)
+
+  @Serializable
+  data class Data(
+    @Serializable(with = TestDoubleLogicalType.TypeSerializer::class)
+    val intValue: MyDoubleType
+  )
+
+  private val data = Data(intValue = MyDoubleType(10.1))
+
+  @Test
+  fun `reads forth and back`() {
+    val record = avroSerialization.toRecord(data)
+    assertThat(avroSerialization.fromRecord(record, Data::class)).isEqualTo(data)
+  }
+
+  @Test
+  fun `reads forth and back from already converted logical type`() {
+    val passedRecord = GenericRecordCodec.decodeSingleObject(
+      singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(avroSerialization.toRecord(data)),
+      readerSchema = avroSchemaResolver(avroSerialization.schema(Data::class)).invoke(),
+    )
+    assertThat(avroSerialization.fromRecord(passedRecord, Data::class)).isEqualTo(data)
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/FloatLogicalTypeSerializerTest.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/FloatLogicalTypeSerializerTest.kt
@@ -1,0 +1,37 @@
+package io.toolisticon.kotlin.avro.serialization.serializer
+
+import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
+import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestFloatLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.avroSerialization
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FloatLogicalTypeSerializerTest {
+
+  data class MyFloatType(val value: Float)
+
+  @Serializable
+  data class Data(
+    @Serializable(with = TestFloatLogicalType.TypeSerializer::class)
+    val intValue: MyFloatType
+  )
+
+  private val data = Data(intValue = MyFloatType(10.1f))
+
+  @Test
+  fun `reads forth and back`() {
+    val record = avroSerialization.toRecord(data)
+    assertThat(avroSerialization.fromRecord(record, Data::class)).isEqualTo(data)
+  }
+
+  @Test
+  fun `reads forth and back from already converted logical type`() {
+    val passedRecord = GenericRecordCodec.decodeSingleObject(
+      singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(avroSerialization.toRecord(data)),
+      readerSchema = avroSchemaResolver(avroSerialization.schema(Data::class)).invoke(),
+    )
+    assertThat(avroSerialization.fromRecord(passedRecord, Data::class)).isEqualTo(data)
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/IntLogicalTypeSerializerTest.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/IntLogicalTypeSerializerTest.kt
@@ -1,0 +1,39 @@
+package io.toolisticon.kotlin.avro.serialization.serializer
+
+import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
+import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestIntLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.avroSerialization
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class IntLogicalTypeSerializerTest {
+
+  data class MyIntType(val value: Int)
+
+  @Serializable
+  data class Data(
+    @Serializable(with = TestIntLogicalType.TypeSerializer::class)
+    val intValue: MyIntType
+  )
+
+  private val data = Data(intValue = MyIntType(10))
+
+  @Test
+  fun `reads forth and back`() {
+    val record = avroSerialization.toRecord(data)
+    assertThat(avroSerialization.fromRecord(record, Data::class)).isEqualTo(data)
+  }
+
+  @Test
+  fun `reads forth and back from already converted logical type`() {
+    val passedRecord = GenericRecordCodec.decodeSingleObject(
+      singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(avroSerialization.toRecord(data)),
+      readerSchema = avroSchemaResolver(avroSerialization.schema(Data::class)).invoke(),
+    )
+    assertThat(avroSerialization.fromRecord(passedRecord, Data::class)).isEqualTo(data)
+  }
+
+
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/LongLogicalTypeSerializerTest.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/LongLogicalTypeSerializerTest.kt
@@ -1,0 +1,39 @@
+package io.toolisticon.kotlin.avro.serialization.serializer
+
+import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
+import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestLongLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.avroSerialization
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LongLogicalTypeSerializerTest {
+
+  data class LongType(val value: Long)
+
+  @Serializable
+  data class Data(
+    @Serializable(with = TestLongLogicalType.TypeSerializer::class)
+    val longValue: LongType
+  )
+
+  private val data = Data(longValue = LongType(10))
+
+  @Test
+  fun `reads forth and back`() {
+    val record = avroSerialization.toRecord(data)
+    assertThat(avroSerialization.fromRecord(record, Data::class)).isEqualTo(data)
+  }
+
+  @Test
+  fun `reads forth and back from already converted logical type`() {
+    val passedRecord = GenericRecordCodec.decodeSingleObject(
+      singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(avroSerialization.toRecord(data)),
+      readerSchema = avroSchemaResolver(avroSerialization.schema(Data::class)).invoke(),
+    )
+    assertThat(avroSerialization.fromRecord(passedRecord, Data::class)).isEqualTo(data)
+  }
+
+
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/StringLogicalTypeSerializerTest.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/StringLogicalTypeSerializerTest.kt
@@ -1,0 +1,37 @@
+package serializer
+
+import io.toolisticon.kotlin.avro.codec.GenericRecordCodec
+import io.toolisticon.kotlin.avro.repository.avroSchemaResolver
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestStringLogicalType
+import io.toolisticon.kotlin.avro.serialization.serializer._fixtures.avroSerialization
+import kotlinx.serialization.Serializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StringLogicalTypeSerializerTest {
+
+  data class StringType(val value: String)
+
+  @Serializable
+  data class Data(
+    @Serializable(with = TestStringLogicalType.TypeSerializer::class)
+    val stringValue: StringType
+  )
+
+  private val data = Data(stringValue = StringType("stringType"))
+
+  @Test
+  fun `reads string forth and back`() {
+    val record = avroSerialization.toRecord(data)
+    assertThat(avroSerialization.fromRecord(record, Data::class)).isEqualTo(data)
+  }
+
+  @Test
+  fun `reads string forth and back from already converted logical type`() {
+    val passedRecord = GenericRecordCodec.decodeSingleObject(
+      singleObjectEncodedBytes = GenericRecordCodec.encodeSingleObject(avroSerialization.toRecord(data)),
+      readerSchema = avroSchemaResolver(avroSerialization.schema(Data::class)).invoke(),
+    )
+    assertThat(avroSerialization.fromRecord(passedRecord, Data::class)).isEqualTo(data)
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/Fixtures.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/Fixtures.kt
@@ -1,0 +1,5 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.serialization.AvroKotlinSerialization
+
+val avroSerialization = AvroKotlinSerialization()

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestBooleanLogicalType.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestBooleanLogicalType.kt
@@ -1,0 +1,29 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.logical.BooleanLogicalType
+import io.toolisticon.kotlin.avro.logical.BooleanLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.conversion.BooleanLogicalTypeConversion
+import io.toolisticon.kotlin.avro.serialization.serializer.BooleanLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.serializer.BooleanLogicalTypeSerializerTest.MyBooleanType
+import io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+import io.toolisticon.kotlin.avro.value.LogicalTypeName.Companion.toLogicalTypeName
+import kotlinx.serialization.modules.SerializersModule
+
+object TestBooleanLogicalType : BooleanLogicalType("boolean-type".toLogicalTypeName()) {
+
+  @Suppress("unused")
+  class LogicalTypeFactory : BooleanLogicalTypeFactory<TestBooleanLogicalType>(logicalType = TestBooleanLogicalType)
+
+  class TypeConversion : BooleanLogicalTypeConversion<TestBooleanLogicalType, MyBooleanType>(TestBooleanLogicalType, MyBooleanType::class) {
+    override fun fromAvro(value: Boolean): MyBooleanType = MyBooleanType(value)
+    override fun toAvro(value: MyBooleanType): Boolean = value.value
+  }
+
+  class TypeSerializer : BooleanLogicalTypeSerializer<TestBooleanLogicalType, MyBooleanType>(TypeConversion())
+
+  class TypeSerializerModuleFactory : AvroSerializerModuleFactory {
+    override fun invoke(): SerializersModule = SerializersModule {
+      contextual(MyBooleanType::class, TypeSerializer())
+    }
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestBytesLogicalType.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestBytesLogicalType.kt
@@ -1,0 +1,35 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.logical.BooleanLogicalType
+import io.toolisticon.kotlin.avro.logical.BooleanLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.BytesLogicalType
+import io.toolisticon.kotlin.avro.logical.BytesLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.conversion.BooleanLogicalTypeConversion
+import io.toolisticon.kotlin.avro.logical.conversion.BytesLogicalTypeConversion
+import io.toolisticon.kotlin.avro.serialization.serializer.BooleanLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.serializer.BooleanLogicalTypeSerializerTest.MyBooleanType
+import io.toolisticon.kotlin.avro.serialization.serializer.BytesLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.serializer.BytesLogicalTypeSerializerTest
+import io.toolisticon.kotlin.avro.serialization.serializer.BytesLogicalTypeSerializerTest.MyBytesType
+import io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+import io.toolisticon.kotlin.avro.value.LogicalTypeName.Companion.toLogicalTypeName
+import kotlinx.serialization.modules.SerializersModule
+
+object TestBytesLogicalType : BytesLogicalType("bytes-type".toLogicalTypeName()) {
+
+  @Suppress("unused")
+  class LogicalTypeFactory : BytesLogicalTypeFactory<TestBytesLogicalType>(logicalType = TestBytesLogicalType)
+
+  class TypeConversion : BytesLogicalTypeConversion<TestBytesLogicalType, MyBytesType>(TestBytesLogicalType, MyBytesType::class) {
+    override fun fromAvro(value: ByteArray): MyBytesType = MyBytesType(value)
+    override fun toAvro(value: MyBytesType): ByteArray = value.value
+  }
+
+  class TypeSerializer : BytesLogicalTypeSerializer<TestBytesLogicalType, MyBytesType>(TypeConversion())
+
+  class TypeSerializerModuleFactory : AvroSerializerModuleFactory {
+    override fun invoke(): SerializersModule = SerializersModule {
+      contextual(MyBytesType::class, TypeSerializer())
+    }
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestDoubleLogicalType.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestDoubleLogicalType.kt
@@ -1,0 +1,28 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.logical.*
+import io.toolisticon.kotlin.avro.logical.conversion.DoubleLogicalTypeConversion
+import io.toolisticon.kotlin.avro.serialization.serializer.*
+import io.toolisticon.kotlin.avro.serialization.serializer.DoubleLogicalTypeSerializerTest.MyDoubleType
+import io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+import io.toolisticon.kotlin.avro.value.LogicalTypeName.Companion.toLogicalTypeName
+import kotlinx.serialization.modules.SerializersModule
+
+object TestDoubleLogicalType : DoubleLogicalType("double-type".toLogicalTypeName()) {
+
+  @Suppress("unused")
+  class LogicalTypeFactory : DoubleLogicalTypeFactory<TestDoubleLogicalType>(logicalType = TestDoubleLogicalType)
+
+  class TypeConversion : DoubleLogicalTypeConversion<TestDoubleLogicalType, MyDoubleType>(TestDoubleLogicalType, MyDoubleType::class) {
+    override fun fromAvro(value: Double): MyDoubleType = MyDoubleType(value)
+    override fun toAvro(value: MyDoubleType): Double = value.value
+  }
+
+  class TypeSerializer : DoubleLogicalTypeSerializer<TestDoubleLogicalType, MyDoubleType>(TypeConversion())
+
+  class TypeSerializerModuleFactory : AvroSerializerModuleFactory {
+    override fun invoke(): SerializersModule = SerializersModule {
+      contextual(MyDoubleType::class, TypeSerializer())
+    }
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestFloatLogicalType.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestFloatLogicalType.kt
@@ -1,0 +1,35 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.logical.FloatLogicalType
+import io.toolisticon.kotlin.avro.logical.FloatLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.IntLogicalType
+import io.toolisticon.kotlin.avro.logical.IntLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.conversion.FloatLogicalTypeConversion
+import io.toolisticon.kotlin.avro.logical.conversion.IntLogicalTypeConversion
+import io.toolisticon.kotlin.avro.serialization.serializer.FloatLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.serializer.FloatLogicalTypeSerializerTest
+import io.toolisticon.kotlin.avro.serialization.serializer.FloatLogicalTypeSerializerTest.*
+import io.toolisticon.kotlin.avro.serialization.serializer.IntLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.serializer.IntLogicalTypeSerializerTest.MyIntType
+import io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+import io.toolisticon.kotlin.avro.value.LogicalTypeName.Companion.toLogicalTypeName
+import kotlinx.serialization.modules.SerializersModule
+
+object TestFloatLogicalType : FloatLogicalType("float-type".toLogicalTypeName()) {
+
+  @Suppress("unused")
+  class LogicalTypeFactory : FloatLogicalTypeFactory<TestFloatLogicalType>(logicalType = TestFloatLogicalType)
+
+  class TypeConversion : FloatLogicalTypeConversion<TestFloatLogicalType, MyFloatType>(TestFloatLogicalType, MyFloatType::class) {
+    override fun fromAvro(value: Float): MyFloatType = MyFloatType(value)
+    override fun toAvro(value: MyFloatType): Float = value.value
+  }
+
+  class TypeSerializer : FloatLogicalTypeSerializer<TestFloatLogicalType, MyFloatType>(TypeConversion())
+
+  class TypeSerializerModuleFactory : AvroSerializerModuleFactory {
+    override fun invoke(): SerializersModule = SerializersModule {
+      contextual(MyFloatType::class, TypeSerializer())
+    }
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestIntLogicalType.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestIntLogicalType.kt
@@ -1,0 +1,29 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.logical.IntLogicalType
+import io.toolisticon.kotlin.avro.logical.IntLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.conversion.IntLogicalTypeConversion
+import io.toolisticon.kotlin.avro.serialization.serializer.IntLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.serializer.IntLogicalTypeSerializerTest.MyIntType
+import io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+import io.toolisticon.kotlin.avro.value.LogicalTypeName.Companion.toLogicalTypeName
+import kotlinx.serialization.modules.SerializersModule
+
+object TestIntLogicalType : IntLogicalType("int-type".toLogicalTypeName()) {
+
+  @Suppress("unused")
+  class LogicalTypeFactory : IntLogicalTypeFactory<TestIntLogicalType>(logicalType = TestIntLogicalType)
+
+  class TypeConversion : IntLogicalTypeConversion<TestIntLogicalType, MyIntType>(TestIntLogicalType, MyIntType::class) {
+    override fun fromAvro(value: Int): MyIntType = MyIntType(value)
+    override fun toAvro(value: MyIntType): Int = value.value
+  }
+
+  class TypeSerializer : IntLogicalTypeSerializer<TestIntLogicalType, MyIntType>(TypeConversion())
+
+  class TypeSerializerModuleFactory : AvroSerializerModuleFactory {
+    override fun invoke(): SerializersModule = SerializersModule {
+      contextual(MyIntType::class, TypeSerializer())
+    }
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestLongLogicalType.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestLongLogicalType.kt
@@ -1,0 +1,29 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.logical.LongLogicalType
+import io.toolisticon.kotlin.avro.logical.LongLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.conversion.LongLogicalTypeConversion
+import io.toolisticon.kotlin.avro.serialization.serializer.LongLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.serializer.LongLogicalTypeSerializerTest.LongType
+import io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+import io.toolisticon.kotlin.avro.value.LogicalTypeName.Companion.toLogicalTypeName
+import kotlinx.serialization.modules.SerializersModule
+
+object TestLongLogicalType : LongLogicalType("long-type".toLogicalTypeName()) {
+
+  @Suppress("unused")
+  class LogicalTypeFactory : LongLogicalTypeFactory<TestLongLogicalType>(logicalType = TestLongLogicalType)
+
+  class TypeConversion : LongLogicalTypeConversion<TestLongLogicalType, LongType>(TestLongLogicalType, LongType::class) {
+    override fun fromAvro(value: Long): LongType = LongType(value)
+    override fun toAvro(value: LongType): Long = value.value
+  }
+
+  class TypeSerializer : LongLogicalTypeSerializer<TestLongLogicalType, LongType>(TypeConversion())
+
+  class TypeSerializerModuleFactory : AvroSerializerModuleFactory {
+    override fun invoke(): SerializersModule = SerializersModule {
+      contextual(LongType::class, TypeSerializer())
+    }
+  }
+}

--- a/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestStringLogicalType.kt
+++ b/avro-kotlin-serialization/src/test/kotlin/serializer/_fixtures/TestStringLogicalType.kt
@@ -1,0 +1,28 @@
+package io.toolisticon.kotlin.avro.serialization.serializer._fixtures
+
+import io.toolisticon.kotlin.avro.logical.StringLogicalType
+import io.toolisticon.kotlin.avro.logical.StringLogicalTypeFactory
+import io.toolisticon.kotlin.avro.logical.conversion.StringLogicalTypeConversion
+import io.toolisticon.kotlin.avro.serialization.serializer.StringLogicalTypeSerializer
+import io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+import io.toolisticon.kotlin.avro.value.LogicalTypeName.Companion.toLogicalTypeName
+import kotlinx.serialization.modules.SerializersModule
+import serializer.StringLogicalTypeSerializerTest.StringType
+
+object TestStringLogicalType : StringLogicalType("string-type".toLogicalTypeName()) {
+
+  class LogicalTypeFactory : StringLogicalTypeFactory<TestStringLogicalType>(logicalType = TestStringLogicalType)
+
+  class TypeConversion : StringLogicalTypeConversion<TestStringLogicalType, StringType>(TestStringLogicalType, StringType::class) {
+    override fun fromAvro(value: String): StringType = StringType(value)
+    override fun toAvro(value: StringType): String = value.value
+  }
+
+  class TypeSerializer : StringLogicalTypeSerializer<TestStringLogicalType, StringType>(TypeConversion())
+
+  class TypeSerializerModuleFactory : AvroSerializerModuleFactory {
+    override fun invoke(): SerializersModule = SerializersModule {
+      contextual(StringType::class, TypeSerializer())
+    }
+  }
+}

--- a/avro-kotlin-serialization/src/test/resources/META-INF/services/io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
+++ b/avro-kotlin-serialization/src/test/resources/META-INF/services/io.toolisticon.kotlin.avro.serialization.spi.AvroSerializerModuleFactory
@@ -1,0 +1,7 @@
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestStringLogicalType$TypeSerializerModuleFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestIntLogicalType$TypeSerializerModuleFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestFloatLogicalType$TypeSerializerModuleFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestLongLogicalType$TypeSerializerModuleFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestDoubleLogicalType$TypeSerializerModuleFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBooleanLogicalType$TypeSerializerModuleFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBytesLogicalType$TypeSerializerModuleFactory

--- a/avro-kotlin-serialization/src/test/resources/META-INF/services/org.apache.avro.Conversion
+++ b/avro-kotlin-serialization/src/test/resources/META-INF/services/org.apache.avro.Conversion
@@ -1,0 +1,7 @@
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestStringLogicalType$TypeConversion
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestLongLogicalType$TypeConversion
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestIntLogicalType$TypeConversion
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestFloatLogicalType$TypeConversion
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestDoubleLogicalType$TypeConversion
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBooleanLogicalType$TypeConversion
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBytesLogicalType$TypeConversion

--- a/avro-kotlin-serialization/src/test/resources/META-INF/services/org.apache.avro.LogicalTypes$LogicalTypeFactory
+++ b/avro-kotlin-serialization/src/test/resources/META-INF/services/org.apache.avro.LogicalTypes$LogicalTypeFactory
@@ -1,0 +1,7 @@
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestStringLogicalType$LogicalTypeFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestLongLogicalType$LogicalTypeFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestIntLogicalType$LogicalTypeFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestFloatLogicalType$LogicalTypeFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestDoubleLogicalType$LogicalTypeFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBooleanLogicalType$LogicalTypeFactory
+io.toolisticon.kotlin.avro.serialization.serializer._fixtures.TestBytesLogicalType$LogicalTypeFactory

--- a/lib/avro4k-core/pom.xml
+++ b/lib/avro4k-core/pom.xml
@@ -13,6 +13,11 @@
   <name>lib: ${project.artifactId}</name>
   <description>Replace outdated dependencies of com.github.avro-kotlin.avro4k/avro4k-core.</description>
 
+  <properties>
+    <jacoco.skip>true</jacoco.skip>
+    <skipTests>true</skipTests>
+  </properties>
+
   <dependencies>
     <!-- AVRO4K(${avro4k.version}) -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <version>1.11.4.4-SNAPSHOT</version>
 
   <name>pom: ${project.artifactId}</name>
-  <description>Root of Opinionated extension functions and helpers for using Apache Avro with Kotlin.</description>
+  <description>Root of opinionated extension functions and helpers for using Apache Avro with Kotlin.</description>
   <url>https://github.com/toolisticon/avro-kotlin/</url>
   <packaging>pom</packaging>
 
@@ -84,6 +84,7 @@
       </activation>
       <modules>
         <module>_examples</module>
+        <module>_mvn/coverage-aggregator</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
- proposed a fix avoid exception on double de-serialization, 
- fix #83 for string